### PR TITLE
Fix regex conditional for darwin

### DIFF
--- a/lib/keybase/local/config.rb
+++ b/lib/keybase/local/config.rb
@@ -50,7 +50,7 @@ module Keybase
       def running?
         if Gem.win_platform?
           !`tasklist | find "keybase.exe"`.empty?
-        elsif /darwin/.match? RUBY_PLATFORM
+        elsif /darwin/ =~ RUBY_PLATFORM
           !`pgrep keybase`.empty?
         else
           # is there a more efficient way to do this that doesn't involve an exec?


### PR DESCRIPTION
`.match?` doesn't seem to work as expected, this does.

Before:

```
NoMethodError: undefined method `match?' for /darwin/:Regexp
```

After: no error.